### PR TITLE
Fix: defer slow google-cloud-bigquery import/client construction past MCP stdio handshake

### DIFF
--- a/src/mcp_server_bigquery/server.py
+++ b/src/mcp_server_bigquery/server.py
@@ -1,5 +1,5 @@
-from google.cloud import bigquery
-from google.oauth2 import service_account
+from __future__ import annotations
+import asyncio
 import logging
 from mcp.server.models import InitializationOptions
 import mcp.types as types
@@ -29,12 +29,22 @@ logger.info("Starting MCP BigQuery Server")
 class BigQueryDatabase:
     def __init__(self, project: str, location: str, key_file: Optional[str], datasets_filter: list[str], timeout: Optional[float] = None):
         """Initialize a BigQuery database client"""
+        # Deferred: `from google.cloud import bigquery` alone measures ~35s cold
+        # (grpcio/protobuf/proto-plus/google-api-core import chain). Importing it
+        # at module load time (the original code) blocks the process before the
+        # stdio loop even opens, racing the MCP client's connect timeout. Doing it
+        # here means it only pays that cost inside the to_thread() call on first
+        # tool use, after the handshake has already succeeded.
+        global bigquery, service_account
+        from google.cloud import bigquery
+        from google.oauth2 import service_account
+
         logger.info(f"Initializing BigQuery client for project: {project}, location: {location}, key_file: {key_file}")
         if not project:
             raise ValueError("Project is required")
         if not location:
             raise ValueError("Location is required")
-        
+
         credentials: service_account.Credentials | None = None
         if key_file:
             try:
@@ -59,7 +69,7 @@ class BigQueryDatabase:
                 job = self.client.query(query, job_config=bigquery.QueryJobConfig(query_parameters=params))
             else:
                 job = self.client.query(query)
-                
+
             results = job.result(timeout=self.timeout)
             rows = [dict(row.items()) for row in results]
             logger.debug(f"Query returned {len(rows)} rows")
@@ -67,7 +77,7 @@ class BigQueryDatabase:
         except Exception as e:
             logger.error(f"Database error executing query: {e}")
             raise
-    
+
     def list_tables(self) -> list[str]:
         """List all tables in the BigQuery database"""
         logger.debug("Listing all tables")
@@ -112,8 +122,25 @@ class BigQueryDatabase:
 async def main(project: str, location: str, key_file: Optional[str], datasets_filter: list[str], timeout: Optional[float] = None):
     logger.info(f"Starting BigQuery MCP Server with project: {project} and location: {location}")
 
-    db = BigQueryDatabase(project, location, key_file, datasets_filter, timeout)
     server = Server("bigquery-manager")
+
+    # Constructing BigQueryDatabase() imports/initializes the google-cloud-bigquery
+    # client, which is slow (cold import alone can exceed 30s) and was previously
+    # done synchronously before the stdio loop started, causing the MCP client's
+    # connect timeout to race a client that hadn't even started reading stdin yet.
+    # Defer construction to first tool call, off the event loop, so the stdio
+    # handshake completes immediately.
+    db_holder: dict[str, BigQueryDatabase] = {}
+    db_lock = asyncio.Lock()
+
+    async def get_db() -> BigQueryDatabase:
+        if "db" not in db_holder:
+            async with db_lock:
+                if "db" not in db_holder:
+                    db_holder["db"] = await asyncio.to_thread(
+                        BigQueryDatabase, project, location, key_file, datasets_filter, timeout
+                    )
+        return db_holder["db"]
 
     # Register handlers
     logger.debug("Registering handlers")
@@ -162,20 +189,22 @@ async def main(project: str, location: str, key_file: Optional[str], datasets_fi
         logger.debug(f"Handling tool execution request: {name}")
 
         try:
+            db = await get_db()
+
             if name == "list-tables":
-                results = db.list_tables()
+                results = await asyncio.to_thread(db.list_tables)
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "describe-table":
                 if not arguments or "table_name" not in arguments:
                     raise ValueError("Missing table_name argument")
-                results = db.describe_table(arguments["table_name"])
+                results = await asyncio.to_thread(db.describe_table, arguments["table_name"])
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "execute-query":
                 if not arguments or "query" not in arguments:
                     raise ValueError("Missing query argument")
-                results = db.execute_query(arguments["query"])
+                results = await asyncio.to_thread(db.execute_query, arguments["query"])
                 return [types.TextContent(type="text", text=str(results))]
 
             else:


### PR DESCRIPTION
## Problem

`main()` currently imports `google.cloud.bigquery` at module load time and constructs `BigQueryDatabase` (which builds a `bigquery.Client`) synchronously, **before** `mcp.server.stdio.stdio_server()` opens. That means the process can't read/respond to the MCP `initialize` handshake until both finish.

Measured in isolation:
```
from google.cloud import bigquery        # ~35-40s cold (grpcio/protobuf/proto-plus/google-api-core chain)
bigquery.Client(credentials=None, ...)   # ~5s
```

Several MCP clients (e.g. Claude Code) enforce a connect timeout well under that (30s), so this server reliably loses the race on cold starts, surfacing as a generic "connection timed out" error with no indication of the actual cause.

The same anti-pattern shows up again inside `handle_call_tool`: `list_tables`/`describe_table`/`execute_query` run as plain synchronous calls directly on the asyncio event loop. Any slow query, proxy hop, or credential refresh blocks the *entire process* from servicing stdio for its duration — indistinguishable from a dead server to the client.

## Fix

- Move the `google.cloud.bigquery` / `google.oauth2.service_account` imports inside `BigQueryDatabase.__init__` (added `from __future__ import annotations` so the `service_account.Credentials | None` annotation still resolves without eager import).
- Defer `BigQueryDatabase` construction to first tool call via an async `get_db()` helper, using `asyncio.to_thread(...)` + `asyncio.Lock()` so it only runs once, off the event loop.
- Wrap the `list_tables`/`describe_table`/`execute_query` calls in `asyncio.to_thread(...)` inside `handle_call_tool` so slow queries/token refreshes no longer block the stdio loop mid-session.

Net effect: the stdio handshake completes immediately regardless of import/client-construction cost. That cost doesn't disappear — it moves to the first actual tool call — but it now runs off the event loop, so it trades a hard connect-timeout failure for a slower-but-successful first call, and stops mid-session tool calls from freezing the whole server.

## Verification

- `python -m py_compile` passes.
- Isolated import of the patched module: ~2.6s, with `bigquery` confirmed absent from module globals until first `BigQueryDatabase` construction.
- Live-tested against two separate BigQuery MCP server entries in Claude Code that were both reliably failing with `connection timed out after 30000ms` on `/mcp` reconnect before this change, and now reconnect successfully every time.

No behavior change to tool inputs/outputs — this is purely a timing/concurrency fix.